### PR TITLE
fix xhr-polling response header problem.

### DIFF
--- a/polling-xhr.go
+++ b/polling-xhr.go
@@ -98,7 +98,11 @@ func (p *polling) get(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/octet-stream")
+	if p.encoder.isString {
+		w.Header().Set("Content-Type", "text/plain; charset=UTF-8")
+	} else {
+		w.Header().Set("Content-Type", "application/octet-stream")
+	}
 	p.encoder.EncodeTo(w)
 }
 


### PR DESCRIPTION
Hi!

I added codes to change the response header based on the request body.
(node-socke.io-client fails connecting to go-engine.io server without this change)

The following is an implementation of the node version.
https://github.com/Automattic/engine.io/blob/master/lib/transports/polling-xhr.js#L60

Please merge if there is no problem.
