### PR TITLE
Close readerChan on disconnect.

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -241,6 +241,7 @@ func (s *conn) onPacket(decoder *packetDecoder) {
 
 func (s *conn) onClose() {
 	close(s.pingChan)
+	close(s.readerChan)
 	s.server.onClose(s)
 	s.origin = nil
 	s.t = nil


### PR DESCRIPTION
The nextReader channel should be closed when the socket closes.
