### PR TITLE
Return initialized empty array.

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -60,7 +60,7 @@ func newTransportsType(names []string) (transportsType, error) {
 }
 
 func (t transportsType) Upgrades() []string {
-	var ret []string
+	ret := []string{}
 	for name, transport := range t {
 		if transport.handlesUpgrades {
 			ret = append(ret, name)

--- a/transport_test.go
+++ b/transport_test.go
@@ -81,7 +81,10 @@ func TestTransport(t *testing.T) {
 	})
 
 	Convey("Test upgrades", t, func() {
-		So(tt.Upgrades(), ShouldResemble, []string{"t1"})
+		t1, _ := newTransportsType([]string{"t1", "t2"})
+		So(t1.Upgrades(), ShouldResemble, []string{"t1"})
+		t2, _ := newTransportsType([]string{"t2"})
+		So(t2.Upgrades(), ShouldResemble, []string{})
 	})
 
 	Convey("Test get creater", t, func() {


### PR DESCRIPTION
When using `polling` transport only, the Socket.IO client expects an empty upgrades array in the connection info JSON response. It currently returns `null`, causing the client to crash.

See http://play.golang.org/p/Ajvk117MIN for the difference in how `encoding/json` treats an initialized vs. uninitialized array.
