### PR TITLE
wait and retry if the server state is "upgrading" when calling NextWriter

### DIFF
--- a/server_conn.go
+++ b/server_conn.go
@@ -134,7 +134,15 @@ func (c *serverConn) NextReader() (MessageType, io.ReadCloser, error) {
 func (c *serverConn) NextWriter(t MessageType) (io.WriteCloser, error) {
 	switch c.getState() {
 	case stateUpgrading:
-		return nil, fmt.Errorf("upgrading")
+		for i := 0; i < 30; i++ {
+			time.Sleep(50 * time.Millisecond)
+			if c.getState() != stateUpgrading {
+				break
+			}
+		}
+		if c.getState() == stateUpgrading {
+			return nil, fmt.Errorf("upgrading")
+		}
 	case stateNormal:
 	default:
 		return nil, io.EOF


### PR DESCRIPTION
This is a fix to https://github.com/googollee/go-socket.io/issues/52
