### PR TITLE
clean up upgrading ws connection fd

### DIFF
--- a/server_conn.go
+++ b/server_conn.go
@@ -229,8 +229,9 @@ func (c *serverConn) OnPacket(r *parser.PacketDecoder) {
 }
 
 func (c *serverConn) OnClose(server transport.Server) {
-	if server == c.getUpgrade() {
+	if t := c.getUpgrade(); server == t {
 		c.setUpgrading("", nil)
+		t.Close()
 		return
 	}
 	t := c.getCurrent()


### PR DESCRIPTION
If the upgrading connection isn't closed it leaks a file descriptor. 