### PR TITLE
Close websocket when NextReader returns error

### DIFF
--- a/websocket/server.go
+++ b/websocket/server.go
@@ -62,6 +62,7 @@ func (s *Server) serveHTTP(w http.ResponseWriter, r *http.Request) {
 	for {
 		t, r, err := s.conn.NextReader()
 		if err != nil {
+			s.conn.Close()
 			return
 		}
 


### PR DESCRIPTION
According to the docs of gorilla/websocket, one should
close the connection if the reader fails.