### PR TITLE
Make the server decrement the connection count when it returns 503 "too many connections"

### DIFF
--- a/server.go
+++ b/server.go
@@ -5,11 +5,12 @@ import (
 	"crypto/md5"
 	"encoding/base64"
 	"fmt"
-	"github.com/googollee/go-engine.io/polling"
-	"github.com/googollee/go-engine.io/websocket"
 	"net/http"
 	"sync/atomic"
 	"time"
+
+	"github.com/googollee/go-engine.io/polling"
+	"github.com/googollee/go-engine.io/websocket"
 )
 
 type config struct {
@@ -122,6 +123,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		n := atomic.AddInt32(&s.currentConnection, 1)
 		if int(n) > s.config.MaxConnection {
+			atomic.AddInt32(&s.currentConnection, -1)
 			http.Error(w, "too many connections", http.StatusServiceUnavailable)
 			return
 		}

--- a/server_test.go
+++ b/server_test.go
@@ -1,10 +1,16 @@
 package engineio
 
 import (
+	"bytes"
+	"encoding/json"
+	"io"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/googollee/go-engine.io/parser"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -36,4 +42,50 @@ func TestServer(t *testing.T) {
 		})
 
 	})
+
+	Convey("Max connections", t, func() {
+		server, _ := NewServer(nil)
+		server.SetMaxConnection(1)
+
+		go func() {
+			for i := 0; i < 3; i++ {
+				server.Accept()
+			}
+		}()
+
+		req1 := newOpenReq()
+		res1 := httptest.NewRecorder()
+		server.ServeHTTP(res1, req1)
+		So(res1.Code, ShouldEqual, 200)
+
+		req2 := newOpenReq()
+		res2 := httptest.NewRecorder()
+		server.ServeHTTP(res2, req2)
+		So(res2.Code, ShouldEqual, 503)
+		So(strings.TrimSpace(string(res2.Body.Bytes())), ShouldEqual, "too many connections")
+
+		server.onClose(extractSid(res1.Body))
+
+		req3 := newOpenReq()
+		res3 := httptest.NewRecorder()
+		server.ServeHTTP(res3, req3)
+		So(res3.Code, ShouldEqual, 200)
+
+	})
+}
+
+func newOpenReq() *http.Request {
+	openReq, _ := http.NewRequest("GET", "/", bytes.NewBuffer([]byte{}))
+	q := openReq.URL.Query()
+	q.Set("transport", "polling")
+	openReq.URL.RawQuery = q.Encode()
+	return openReq
+}
+
+func extractSid(body io.Reader) string {
+	payload := parser.NewPayloadDecoder(body)
+	packet, _ := payload.Next()
+	openRes := map[string]interface{}{}
+	json.NewDecoder(packet).Decode(&openRes)
+	return openRes["sid"].(string)
 }


### PR DESCRIPTION
On every open request, the server increments its current connection count, but it does not correctly decrement it when a connection errors out because of too many connections. This effectively makes every connection over the connection limit cause the connection count to grow and grow.