### PR TITLE
Fix intermittent bug where false positive ping timeout causes connection to be closed prematurely

### DIFF
--- a/polling/writer.go
+++ b/polling/writer.go
@@ -25,8 +25,11 @@ func (w *Writer) Close() error {
 	if w.server.getState() != stateNormal {
 		return errors.New("use of closed network connection")
 	}
+	w.server.sendChanMu.Lock()
+	sendChan := w.server.sendChan
+	w.server.sendChanMu.Unlock()
 	select {
-	case w.server.sendChan <- true:
+	case sendChan <- true:
 	default:
 	}
 	return w.WriteCloser.Close()

--- a/polling/writer_test.go
+++ b/polling/writer_test.go
@@ -12,7 +12,9 @@ func TestWriter(t *testing.T) {
 		state:    stateNormal,
 		sendChan: MakeSendChan(),
 	}
+	p.sendChanMu.Lock()
 	sendChan := p.sendChan
+	p.sendChanMu.Unlock()
 
 	Convey("Wait close", t, func() {
 		w := newFakeWriteCloser()

--- a/server_conn.go
+++ b/server_conn.go
@@ -375,8 +375,10 @@ func (c *serverConn) pingLoop() {
 			}
 			lastTry = time.Now()
 		case <-pingTimedOut.C:
-			c.Close()
-			return
+			if c.getState() == stateNormal {
+				c.Close()
+				return
+			}
 		}
 		now = time.Now()
 	}

--- a/websocket/websocket_test.go
+++ b/websocket/websocket_test.go
@@ -334,8 +334,12 @@ func TestWebsocket(t *testing.T) {
 		defer c.Close()
 
 		<-sync
+
 		// So(f.ClosedCount(), ShouldEqual, 1)
-		So(f.closeServer, ShouldEqual, s)
+		f.countLocker.Lock()
+		closeServer := f.closeServer
+		f.countLocker.Unlock()
+		So(closeServer, ShouldEqual, s)
 	})
 
 	Convey("Closing by disconnected", t, func() {


### PR DESCRIPTION
This is an intermittent bug - it happens when there are many concurrent connections are being made. I modified `example/assets/index.js` to show this behavior ([available here](https://github.com/holygeek/go-engine.io/tree/many)).

Buggy behavior (notice the charts where the background are red):

![bad](http://i.imgur.com/uuKP0I2.png)

Correct behavior:

![good](http://i.imgur.com/QSrJxRh.png)