### PR TITLE
websocket transport no need to WriteHeader in ServeHTTP mehtod

### DIFF
--- a/server.go
+++ b/server.go
@@ -143,6 +143,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		var err error
 		conn, err = newServerConn(sid, w, r, s)
 		if err != nil {
+			atomic.AddInt32(&s.currentConnection, -1)
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}

--- a/websocket/server.go
+++ b/websocket/server.go
@@ -32,7 +32,6 @@ func NewServer(w http.ResponseWriter, r *http.Request, callback transport.Callba
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	w.WriteHeader(http.StatusBadRequest)
 }
 
 func (s *Server) NextWriter(msgType message.MessageType, packetType parser.PacketType) (io.WriteCloser, error) {


### PR DESCRIPTION
websocket transport no need to WriteHeader in ServeHTTP mehtod because the request has been hjacked. 

see #35 .