### PR TITLE
fix conn count bug

### DIFF
--- a/server.go
+++ b/server.go
@@ -143,6 +143,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		var err error
 		conn, err = newServerConn(sid, w, r, s)
 		if err != nil {
+			atomic.AddInt32(&s.currentConnection, -1)
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}


### PR DESCRIPTION
使用了这个库，一晚上过来发现所有请求都503了，错误是too many connections，但是查看tcp连接却很少，
查下来是没有在创建conn失败的时候减小统计值，提交该修复如上