### PR TITLE
Concurrent close/write in connection

### DIFF
--- a/session.go
+++ b/session.go
@@ -143,6 +143,7 @@ func (s *session) nextReader() (base.FrameType, base.PacketType, io.ReadCloser, 
 			}
 			return 0, 0, nil, err
 		}
+		s.upgradeLocker.RUnlock()
 		return ft, pt, newReader(r, &s.upgradeLocker), nil
 	}
 }
@@ -160,6 +161,7 @@ func (s *session) nextWriter(ft base.FrameType, pt base.PacketType) (io.WriteClo
 			}
 			return nil, err
 		}
+		s.upgradeLocker.RUnlock()
 		return newWriter(w, &s.upgradeLocker), nil
 	}
 }

--- a/util.go
+++ b/util.go
@@ -23,7 +23,6 @@ func (w *writer) Close() (err error) {
 	w.closeOnce.Do(func() {
 		w.locker.Lock()
 		defer w.locker.Unlock()
-		defer w.locker.RUnlock()
 		err = w.WriteCloser.Close()
 	})
 
@@ -63,6 +62,6 @@ func (r *reader) Close() (err error) {
 func (r *reader) Read(p []byte) (n int, err error) {
 	r.locker.RLock()
 	defer r.locker.RUnlock()
-	n, err = r.Read(p)
+	n, err = r.ReadCloser.Read(p)
 	return
 }

--- a/util.go
+++ b/util.go
@@ -19,12 +19,21 @@ func newWriter(w io.WriteCloser, locker *sync.RWMutex) *writer {
 	}
 }
 
-func (w *writer) Close() error {
-	err := w.WriteCloser.Close()
+func (w *writer) Close() (err error) {
 	w.closeOnce.Do(func() {
-		w.locker.RUnlock()
+		w.locker.Lock()
+		defer w.locker.Unlock()
+		defer w.locker.RUnlock()
+		err = w.WriteCloser.Close()
 	})
-	return err
+
+	return
+}
+
+func (w *writer) Write(p []byte) (int, error) {
+	w.locker.Lock()
+	defer w.locker.Unlock()
+	return w.WriteCloser.Write(p)
 }
 
 type reader struct {
@@ -40,11 +49,20 @@ func newReader(r io.ReadCloser, locker *sync.RWMutex) *reader {
 	}
 }
 
-func (r *reader) Close() error {
-	io.Copy(ioutil.Discard, r.ReadCloser)
-	err := r.ReadCloser.Close()
+func (r *reader) Close() (err error) {
 	r.closeOnce.Do(func() {
+		r.locker.RLock()
+		io.Copy(ioutil.Discard, r.ReadCloser)
+		err = r.ReadCloser.Close()
 		r.locker.RUnlock()
 	})
-	return err
+
+	return
+}
+
+func (r *reader) Read(p []byte) (n int, err error) {
+	r.locker.RLock()
+	defer r.locker.RUnlock()
+	n, err = r.Read(p)
+	return
 }


### PR DESCRIPTION
Just received:
```
panic: concurrent write to websocket connection

goroutine 33 [running]:
github.com/gorilla/websocket.(*messageWriter).flushFrame(0xc4206f95f0, 0xc420052a01, 0x0, 0x0, 0x0, 0x574cfe, 0xc4206f9620)
       mypath/src/github.com/gorilla/websocket/conn.go:587 +0x67a
github.com/gorilla/websocket.(*messageWriter).Close(0xc4206f95f0, 0x18, 0xc4200abb00)
       mypath/src/github.com/gorilla/websocket/conn.go:701 +0x5f
github.com/tensor146/go-engine%2eio.(*writer).Close(0xc4206f9620, 0x0, 0x43c9c3)
       mypath/src/github.com/tensor146/go-engine.io/util.go:23 +0x37
github.com/tensor146/go-socket.io/parser.(*Encoder).writePacket(0xc420504320, 0xbba6a0, 0xc4206f9620, 0x2, 0x0, 0x0, 0x235e, 0x1, 0xc4203929a0, 0x2, ...)
       mypath/src/github.com/tensor146/go-socket.io/parser/encoder.go:124 +0x359
github.com/tensor146/go-socket.io/parser.(*Encoder).Encode(0xc420504320, 0x2, 0x0, 0x0, 0x235e, 0x1, 0xc4203929a0, 0x2, 0x2, 0x0, ...)
       mypath/src/github.com/tensor146/go-socket.io/parser/encoder.go:40 +0x140
github.com/tensor146/go-socket%2eio.(*conn).serveWrite(0xc4200d6460)
       mypath/src/github.com/tensor146/go-socket.io/conn.go:168 +0x1d9
created by github.com/tensor146/go-socket%2eio.newConn
       mypath/src/github.com/tensor146/go-socket.io/conn.go:78 +0x305
exit status 2
```

So I used RWMutex to avoid concurrent Close() and Read()/Write() ops.