### PR TITLE
Set state of closing before closing the socket

### DIFF
--- a/polling/server.go
+++ b/polling/server.go
@@ -60,8 +60,8 @@ func (p *Polling) Close() error {
 	if p.getState() != stateNormal {
 		return nil
 	}
-	close(p.sendChan)
 	p.setState(stateClosing)
+	close(p.sendChan)
 	if p.getLocker.TryLock() {
 		if p.postLocker.TryLock() {
 			p.callback.OnClose(p)


### PR DESCRIPTION
Closes https://github.com/googollee/go-engine.io/issues/53

This reduces the number of panics by a lot, but this package is still not error free. I've been running this in production with over 10000+ connected clients average, and it seems to fix the error without any negative impacts. So I'm merging this instantly. If anyone disagrees feel free to comment and we can discuss it :)