### PR TITLE
safety check for double upgrade

### DIFF
--- a/polling/client.go
+++ b/polling/client.go
@@ -2,13 +2,15 @@ package polling
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
-	"github.com/googollee/go-engine.io/message"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"time"
+
+	"github.com/googollee/go-engine.io/message"
 
 	"github.com/googollee/go-engine.io/parser"
 	"github.com/googollee/go-engine.io/transport"
@@ -74,6 +76,9 @@ func (c *client) NextReader() (*parser.PacketDecoder, error) {
 }
 
 func (c *client) NextWriter(messageType message.MessageType, packetType parser.PacketType) (io.WriteCloser, error) {
+	if c == nil {
+		return nil, errors.New("client.NextWriter() on nil client")
+	}
 	if c.state != stateNormal {
 		return nil, io.EOF
 	}

--- a/polling/server.go
+++ b/polling/server.go
@@ -2,6 +2,7 @@ package polling
 
 import (
 	"bytes"
+	"errors"
 	"html/template"
 	"io"
 	"net/http"
@@ -74,6 +75,9 @@ func (p *Polling) Close() error {
 }
 
 func (p *Polling) NextWriter(msgType message.MessageType, packetType parser.PacketType) (io.WriteCloser, error) {
+	if p == nil {
+		return nil, errors.New("polling.NextWriter() on nil polling")
+	}
 	if p.getState() != stateNormal {
 		return nil, io.EOF
 	}

--- a/server_conn.go
+++ b/server_conn.go
@@ -337,13 +337,12 @@ func (c *serverConn) setUpgrading(name string, s transport.Server) {
 }
 
 func (c *serverConn) upgraded() {
-	c.transportLocker.Lock()
-
 	if c.upgrading == nil {
 		fmt.Println("Bypass double upgrade from IP", c.request.RemoteAddr)
 		return
 	}
 
+	c.transportLocker.Lock()
 	current := c.current
 	c.current = c.upgrading
 	c.currentName = c.upgradingName

--- a/server_conn.go
+++ b/server_conn.go
@@ -133,6 +133,9 @@ func (c *serverConn) NextReader() (MessageType, io.ReadCloser, error) {
 }
 
 func (c *serverConn) NextWriter(t MessageType) (io.WriteCloser, error) {
+	if c == nil {
+		return nil, errors.New("serverConn.NextWriter() on nil serverConn")
+	}
 	switch c.getState() {
 	case stateUpgrading:
 		for i := 0; i < 30; i++ {
@@ -300,6 +303,9 @@ func (s *serverConn) onOpen() error {
 }
 
 func (c *serverConn) getCurrent() transport.Server {
+	if c == nil {
+		return nil
+	}
 	c.transportLocker.RLock()
 	defer c.transportLocker.RUnlock()
 
@@ -332,6 +338,11 @@ func (c *serverConn) setUpgrading(name string, s transport.Server) {
 
 func (c *serverConn) upgraded() {
 	c.transportLocker.Lock()
+
+	if c.upgrading == nil {
+		fmt.Println("Bypass double upgrade from IP", c.request.RemoteAddr)
+		return
+	}
 
 	current := c.current
 	c.current = c.upgrading

--- a/server_conn.go
+++ b/server_conn.go
@@ -338,7 +338,6 @@ func (c *serverConn) setUpgrading(name string, s transport.Server) {
 
 func (c *serverConn) upgraded() {
 	if c.upgrading == nil {
-		fmt.Println("Bypass double upgrade from IP", c.request.RemoteAddr)
 		return
 	}
 

--- a/websocket/client.go
+++ b/websocket/client.go
@@ -1,6 +1,7 @@
 package websocket
 
 import (
+	"errors"
 	"io"
 	"net/http"
 
@@ -51,6 +52,9 @@ func (c *client) NextReader() (*parser.PacketDecoder, error) {
 }
 
 func (c *client) NextWriter(msgType message.MessageType, packetType parser.PacketType) (io.WriteCloser, error) {
+	if c == nil {
+		return nil, errors.New("client.NextWriter() on nil client")
+	}
 	wsType, newEncoder := websocket.TextMessage, parser.NewStringEncoder
 	if msgType == message.MessageBinary {
 		wsType, newEncoder = websocket.BinaryMessage, parser.NewBinaryEncoder

--- a/websocket/server.go
+++ b/websocket/server.go
@@ -1,6 +1,7 @@
 package websocket
 
 import (
+	"errors"
 	"io"
 	"net/http"
 
@@ -36,6 +37,9 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) NextWriter(msgType message.MessageType, packetType parser.PacketType) (io.WriteCloser, error) {
+	if s == nil {
+		return nil, errors.New("server.NextWriter() on nil server")
+	}
 	wsType, newEncoder := websocket.TextMessage, parser.NewStringEncoder
 	if msgType == message.MessageBinary {
 		wsType, newEncoder = websocket.BinaryMessage, parser.NewBinaryEncoder


### PR DESCRIPTION
If a server receives an upgrade req while its in the middle of an upgrade, the state transition ends up with a nil ptr for current.

Subsequent calls to current.NextWriter() will then cause the server to panic with a nil ptr exception ... taking out the server.