### PR TITLE
fix: concurrent write to websocket connection panic #74

### DIFF
--- a/transport/websocket/conn.go
+++ b/transport/websocket/conn.go
@@ -56,7 +56,10 @@ func (c *conn) SetReadDeadline(t time.Time) error {
 }
 
 func (c *conn) SetWriteDeadline(t time.Time) error {
-	return c.ws.SetWriteDeadline(t)
+	c.ws.writeLocker.Lock()
+	err := c.ws.SetWriteDeadline(t)
+	c.ws.writeLocker.Unlock()
+	return err
 }
 
 func (c *conn) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/transport/websocket/wrapper.go
+++ b/transport/websocket/wrapper.go
@@ -3,6 +3,7 @@ package websocket
 import (
 	"io"
 	"io/ioutil"
+	"sync"
 
 	"github.com/googollee/go-engine.io/base"
 	"github.com/googollee/go-engine.io/transport"
@@ -11,11 +12,13 @@ import (
 
 type wrapper struct {
 	*websocket.Conn
+	writeLocker *sync.Mutex
 }
 
 func newWrapper(conn *websocket.Conn) wrapper {
 	return wrapper{
 		Conn: conn,
+		writeLocker: new(sync.Mutex),
 	}
 }
 
@@ -44,5 +47,8 @@ func (w wrapper) NextWriter(typ base.FrameType) (io.WriteCloser, error) {
 	default:
 		return nil, transport.ErrInvalidFrame
 	}
-	return w.Conn.NextWriter(t)
+	w.writeLocker.Lock()
+	writer, err := w.Conn.NextWriter(t)
+	w.writeLocker.Unlock()
+	return writer, err
 }


### PR DESCRIPTION
as https://godoc.org/github.com/gorilla/websocket#hdr-Concurrency said,
Connections support one concurrent reader and one concurrent writer.
Applications are responsible for ensuring that no more than one goroutine calls the write methods (NextWriter, SetWriteDeadline, WriteMessage, WriteJSON, EnableWriteCompression, SetCompressionLevel) concurrently and that no more than one goroutine calls the read methods (NextReader, SetReadDeadline, ReadMessage, ReadJSON, SetPongHandler, SetPingHandler) concurrently.

Signed-off-by: Wang Yufei <wangyufei@dobest.com>