### PR TITLE
multiple concurrency fixes

### DIFF
--- a/demo/client/client.go
+++ b/demo/client/client.go
@@ -34,6 +34,7 @@ func main() {
 			}
 			b, err := ioutil.ReadAll(r)
 			if err != nil {
+				r.Close()
 				log.Println("read all error:", err)
 				return
 			}
@@ -53,6 +54,7 @@ func main() {
 			return
 		}
 		if _, err := w.Write([]byte("hello")); err != nil {
+			w.Close()
 			log.Println("write error:", err)
 			return
 		}
@@ -67,6 +69,7 @@ func main() {
 			return
 		}
 		if _, err := w.Write([]byte{1, 2, 3, 4}); err != nil {
+			w.Close()
 			log.Println("write error:", err)
 			return
 		}

--- a/demo/server/server.go
+++ b/demo/server/server.go
@@ -50,6 +50,7 @@ func main() {
 								return
 							}
 							if _, err := w.Write(d.data); err != nil {
+								w.Close()
 								log.Println("write error:", err)
 								return
 							}
@@ -71,6 +72,7 @@ func main() {
 					}
 					b, err := ioutil.ReadAll(r)
 					if err != nil {
+						r.Close()
 						log.Println("read all error:", err)
 						break
 					}

--- a/demo/web/server.go
+++ b/demo/web/server.go
@@ -37,18 +37,18 @@ func main() {
 
 					w, err := conn.NextWriter(ft)
 					if err != nil {
+						r.Close()
 						fmt.Println("write error:", err)
 						return
 					}
 
 					_, err = io.Copy(w, r)
+					w.Close()
+					r.Close()
 					if err != nil {
 						fmt.Println("copy error:", err)
 						return
 					}
-
-					w.Close()
-					r.Close()
 				}
 			}(conn)
 		}

--- a/example_test.go
+++ b/example_test.go
@@ -33,17 +33,23 @@ func ExampleServer() {
 				}
 				w, err := conn.NextWriter(typ)
 				if err != nil {
+					r.Close()
 					log.Fatalln("write error:", err)
 					return
 				}
 				_, err = io.Copy(w, r)
 				if err != nil {
+					r.Close()
+					w.Close()
 					log.Fatalln("copy error:", err)
 					return
 				}
-				err = w.Close()
-				if err != nil {
+				if err = w.Close(); err != nil {
 					log.Fatalln("close writer error:", err)
+					return
+				}
+				if err = r.Close(); err != nil {
+					log.Fatalln("close reader error:", err)
 					return
 				}
 			}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/googollee/go-engine.io
 
+go 1.12
+
 require (
 	github.com/golang/lint v0.0.0-20181217174547-8f45f776aaf1 // indirect
 	github.com/gordonklaus/ineffassign v0.0.0-20180909121442-1003c8bd00dc // indirect

--- a/packet/decoder.go
+++ b/packet/decoder.go
@@ -23,6 +23,7 @@ func (e *decoder) NextReader() (base.FrameType, base.PacketType, io.ReadCloser, 
 	}
 	var b [1]byte
 	if _, err := io.ReadFull(r, b[:]); err != nil {
+		r.Close()
 		return 0, 0, nil, err
 	}
 	return ft, base.ByteToPacketType(b[0], ft), r, nil

--- a/packet/protocol_test.go
+++ b/packet/protocol_test.go
@@ -96,6 +96,7 @@ func TestDecoder(t *testing.T) {
 			}
 			b, err := ioutil.ReadAll(fr)
 			at.Nil(err)
+			fr.Close()
 			output = append(output, Packet{
 				ft:   ft,
 				pt:   pt,
@@ -123,7 +124,9 @@ func BenchmarkDecoder(b *testing.B) {
 	decoder := NewDecoder(r)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		decoder.NextReader()
-		decoder.NextReader()
+		_, _, fr, _ := decoder.NextReader()
+		fr.Close()
+		_, _, fr, _ = decoder.NextReader()
+		fr.Close()
 	}
 }

--- a/server.go
+++ b/server.go
@@ -81,7 +81,6 @@ type Server struct {
 	sessions       *manager
 	requestChecker func(*http.Request) (http.Header, error)
 	connInitor     func(*http.Request, Conn)
-	locker         sync.RWMutex
 	connChan       chan Conn
 	closeOnce      sync.Once
 }

--- a/session.go
+++ b/session.go
@@ -224,6 +224,7 @@ func (s *session) upgrading(t string, conn base.Conn) {
 		return
 	}
 	if pt != base.PING {
+		r.Close()
 		conn.Close()
 		return
 	}
@@ -232,21 +233,26 @@ func (s *session) upgrading(t string, conn base.Conn) {
 	// Sent a pong in reply.
 	err = conn.SetWriteDeadline(time.Now().Add(s.params.PingTimeout))
 	if err != nil {
+		r.Close()
 		conn.Close()
 		return
 	}
 
 	w, err := conn.NextWriter(ft, base.PONG)
 	if err != nil {
+		r.Close()
 		conn.Close()
 		return
 	}
 	// echo
 	if _, err = io.Copy(w, r); err != nil {
+		w.Close()
+		r.Close()
 		conn.Close()
 		return
 	}
 	if err = r.Close(); err != nil {
+		w.Close()
 		conn.Close()
 		return
 	}
@@ -280,6 +286,7 @@ func (s *session) upgrading(t string, conn base.Conn) {
 		return
 	}
 	if pt != base.UPGRADE {
+		r.Close()
 		conn.Close()
 		return
 	}

--- a/session.go
+++ b/session.go
@@ -71,7 +71,7 @@ func (s *session) Close() error {
 }
 
 // NextReader attempts to obtain a ReadCloser from the session's connection.
-// when finished writing, The caller MUST Close the ReadCloser to unlock the
+// When finished writing, the caller MUST Close the ReadCloser to unlock the
 // connection's FramerReader.
 func (s *session) NextReader() (FrameType, io.ReadCloser, error) {
 	for {

--- a/session.go
+++ b/session.go
@@ -111,9 +111,10 @@ func (s *session) NextReader() (FrameType, io.ReadCloser, error) {
 			// Caller must Close the ReadCloser to unlock the connection's
 			// FrameReader when finished reading.
 			return FrameType(ft), r, nil
+		default:
+			// Unknown packet type. Close reader and try again.
+			r.Close()
 		}
-		// Unknown packet type. Close reader and try again.
-		r.Close()
 	}
 }
 

--- a/transport/polling/client.go
+++ b/transport/polling/client.go
@@ -57,10 +57,12 @@ func (c *clientConn) Open() (base.ConnParameters, error) {
 		return base.ConnParameters{}, err
 	}
 	if pt != base.OPEN {
+		r.Close()
 		return base.ConnParameters{}, errors.New("invalid open")
 	}
 	conn, err := base.ReadConnParameters(r)
 	if err != nil {
+		r.Close()
 		return base.ConnParameters{}, err
 	}
 	err = r.Close()

--- a/transport/websocket/conn.go
+++ b/transport/websocket/conn.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gorilla/websocket"
 )
 
+// conn implements base.Conn
 type conn struct {
 	url          url.URL
 	remoteHeader http.Header
@@ -56,6 +57,8 @@ func (c *conn) SetReadDeadline(t time.Time) error {
 }
 
 func (c *conn) SetWriteDeadline(t time.Time) error {
+	// TODO: is locking really needed for SetWriteDeadline? If so, what about
+	// the read deadline?
 	c.ws.writeLocker.Lock()
 	err := c.ws.SetWriteDeadline(t)
 	c.ws.writeLocker.Unlock()

--- a/transport/websocket/websocket_test.go
+++ b/transport/websocket/websocket_test.go
@@ -83,6 +83,8 @@ func TestWebsocket(t *testing.T) {
 			at.Equal(test.pt, pt)
 			b, err := ioutil.ReadAll(r)
 			at.Nil(err)
+			err = r.Close()
+			at.Nil(err)
 			at.Equal(test.data, b)
 
 			w, err := cc.NextWriter(ft, pt)
@@ -107,6 +109,8 @@ func TestWebsocket(t *testing.T) {
 		at.Equal(test.ft, ft)
 		at.Equal(test.pt, pt)
 		b, err := ioutil.ReadAll(r)
+		at.Nil(err)
+		err = r.Close()
 		at.Nil(err)
 		at.Equal(test.data, b)
 	}

--- a/transport/websocket/wrapper.go
+++ b/transport/websocket/wrapper.go
@@ -34,13 +34,13 @@ func (w wrapper) NextReader() (base.FrameType, io.ReadCloser, error) {
 		w.readLocker.Unlock()
 		return 0, nil, err
 	}
-	rc := newRcWrapper(w.readLocker, r)
 	switch typ {
 	case websocket.TextMessage:
-		return base.FrameString, rc, nil
+		return base.FrameString, newRcWrapper(w.readLocker, r), nil
 	case websocket.BinaryMessage:
-		return base.FrameBinary, rc, nil
+		return base.FrameBinary, newRcWrapper(w.readLocker, r), nil
 	}
+	w.readLocker.Unlock()
 	return 0, nil, transport.ErrInvalidFrame
 }
 

--- a/transport/websocket/wrapper.go
+++ b/transport/websocket/wrapper.go
@@ -48,9 +48,9 @@ type rcWrapper struct {
 }
 
 func (r rcWrapper) Close() error {
-	_, err := io.Copy(ioutil.Discard, r)
+	io.Copy(ioutil.Discard, r) // reader may be closed, ignore error
 	r.l.Unlock()
-	return err
+	return nil
 }
 
 func (w wrapper) NextWriter(typ base.FrameType) (io.WriteCloser, error) {

--- a/transport/websocket/wrapper.go
+++ b/transport/websocket/wrapper.go
@@ -1,9 +1,11 @@
 package websocket
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 	"sync"
+	"time"
 
 	"github.com/googollee/go-engine.io/base"
 	"github.com/googollee/go-engine.io/transport"
@@ -32,7 +34,7 @@ func (w wrapper) NextReader() (base.FrameType, io.ReadCloser, error) {
 		w.readLocker.Unlock()
 		return 0, nil, err
 	}
-	rc := rcWrapper{w.readLocker, r}
+	rc := newRcWrapper(w.readLocker, r)
 	switch typ {
 	case websocket.TextMessage:
 		return base.FrameString, rc, nil
@@ -43,12 +45,37 @@ func (w wrapper) NextReader() (base.FrameType, io.ReadCloser, error) {
 }
 
 type rcWrapper struct {
-	l *sync.Mutex
+	nagTimer *time.Timer
+	quitNag  chan struct{}
+	l        *sync.Mutex
 	io.Reader
 }
 
+func newRcWrapper(l *sync.Mutex, r io.Reader) rcWrapper {
+	timer := time.NewTimer(30 * time.Second)
+	q := make(chan struct{})
+	go func() {
+		select {
+		case <-q:
+		case <-timer.C:
+			fmt.Println("Did you forget to Close() the ReadCloser from NextReader?")
+		}
+	}()
+	return rcWrapper{
+		nagTimer: timer,
+		quitNag:  q,
+		l:        l,
+		Reader:   r,
+	}
+}
+
 func (r rcWrapper) Close() error {
+	// Stop the nagger.
+	r.nagTimer.Stop()
+	close(r.quitNag)
+	// Attempt to drain the Reader.
 	io.Copy(ioutil.Discard, r) // reader may be closed, ignore error
+	// Unlock the wrapper's read lock for future calls to NextReader.
 	r.l.Unlock()
 	return nil
 }
@@ -72,15 +99,39 @@ func (w wrapper) NextWriter(typ base.FrameType) (io.WriteCloser, error) {
 		return nil, err
 	}
 
-	return wcWrapper{w.writeLocker, writer}, nil
+	return newWcWrapper(w.writeLocker, writer), nil
 }
 
 type wcWrapper struct {
-	l *sync.Mutex
+	nagTimer *time.Timer
+	quitNag  chan struct{}
+	l        *sync.Mutex
 	io.WriteCloser
 }
 
+func newWcWrapper(l *sync.Mutex, w io.WriteCloser) wcWrapper {
+	timer := time.NewTimer(30 * time.Second)
+	q := make(chan struct{})
+	go func() {
+		select {
+		case <-q:
+		case <-timer.C:
+			fmt.Println("Did you forget to Close() the WriteCloser from NextWriter?")
+		}
+	}()
+	return wcWrapper{
+		nagTimer:    timer,
+		quitNag:     q,
+		l:           l,
+		WriteCloser: w,
+	}
+}
+
 func (w wcWrapper) Close() error {
+	// Stop the nagger.
+	w.nagTimer.Stop()
+	close(w.quitNag)
+	// Unlock the wrapper's write lock for future calls to NextWriter.
 	defer w.l.Unlock()
 	return w.WriteCloser.Close()
 }


### PR DESCRIPTION
The primary issue addressed in this PR is the lack of concurrent access
control to websocket's read methods.  Locking for the write methods was
recently added, but read methods have the same requirement.  From
https://godoc.org/github.com/gorilla/websocket#hdr-Concurrency:

>  Connections support one concurrent reader and one concurrent writer.
>
> Applications are responsible for ensuring that no more than one goroutine calls the write methods (NextWriter, SetWriteDeadline, WriteMessage, WriteJSON, EnableWriteCompression, SetCompressionLevel) concurrently **and that no more than one goroutine calls the read methods** (NextReader, SetReadDeadline, ReadMessage, ReadJSON, SetPongHandler, SetPingHandler) concurrently.
>
> The Close and WriteControl methods can be called concurrently with all other methods.

Similar to how `wrapper.writeLocker` is handled (unlocking on close), this adds a `readLocker` with identical semantics except for reads.  Note that readers from `wrapper.NextReader` must be `Close`d now.

This PR also eliminates the use in `session` of the `reader` and `writer` defined in util.go since it is redundant with the locking in `transport/websocket.wrapper`.

Details:

**session**: `upgradeLocker` is for protecting the `session.conn` field,
not concurrent writes on the actual connection. Only use it that way.

Remove `writeLocker` from `session` since they are in the `wrapper`.

No longer use `util.go`'s `newWriter` and `newReader` from util.go since
the locking is in the `wrapper`.

**util.go**: Changes even though util.go is no longer used.

Use a full write lock, not read lock, with `reader.Close` and `reader.Read`.
With RLock and RUnlock, concurrent reads were not prevented, but this
is a requirement of gorilla's connection read methods too.

Change the locker type in both reader and writer from `*sync.RWMutex`
to `sync.Locker`, which is satisfied by both `Mutex` and `RWMutex`.

Note: util.go is now UNUSED.

**transport/websocket**: `wrapper` needs locking around reads too.

Add `wrapper.readLocker`, and use it in `NextReader`.
Add `rcWrapper`, similar to `wcWrapper`, for unlocking the `wrapper`'s read
lock on `Close`.

**packet**: A failed read from a decoder must close the reader.

As in `(*encoder).NextWriter`, which calls the writer's `Close` method when
a `Write` fails, `(*decoder).NextReader` must call the reader's `Close` method
on a failed read (`io.ReadFull`).

**bonus**: go.mod needs a go version line since Go 1.13 adds one