### PR TITLE
change client timeout to pingInterval+pingTimeout

### DIFF
--- a/client.go
+++ b/client.go
@@ -117,7 +117,7 @@ func (c *client) NextReader() (FrameType, io.ReadCloser, error) {
 		}
 		switch pt {
 		case base.PONG:
-			c.conn.SetReadDeadline(time.Now().Add(c.params.PingTimeout))
+			c.conn.SetReadDeadline(time.Now().Add(c.params.PingInterval + c.params.PingTimeout))
 		case base.CLOSE:
 			c.Close()
 			return 0, nil, io.EOF
@@ -163,6 +163,6 @@ func (c *client) serve() {
 		if err := w.Close(); err != nil {
 			return
 		}
-		c.conn.SetWriteDeadline(time.Now().Add(c.params.PingTimeout))
+		c.conn.SetWriteDeadline(time.Now().Add(c.params.PingInterval + c.params.PingTimeout))
 	}
 }


### PR DESCRIPTION
https://github.com/googollee/go-engine.io/issues/80 

From the documentation of latest version of Socket.IO, `a client may have to wait up to pingTimeout + pingInterval ms before getting a disconnect event`