### PR TITLE
Fix "superfluous response.WriteHeader call [...]" on erroneous connection attempt

### DIFF
--- a/server.go
+++ b/server.go
@@ -1,6 +1,7 @@
 package engineio
 
 import (
+	websocket2 "github.com/gorilla/websocket"
 	"io"
 	"net/http"
 	"sync"
@@ -178,7 +179,11 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if session.Transport() != t {
 		conn, err := tspt.Accept(w, r)
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadGateway)
+			// don't call http.Error() for HandshakeErrors because
+			// they get handled by the websocket library internally.
+			if _, ok := err.(websocket2.HandshakeError); !ok {
+				http.Error(w, err.Error(), http.StatusBadGateway)
+			}
 			return
 		}
 		session.upgrade(t, conn)


### PR DESCRIPTION
### Reproduction steps

1. Setup a connection that makes an erroneous/unsuccessful attempt to establish to a websocket connection
e.g. by passing a CheckOrigin function that always returns false:
```
opt := &engineio.Options{
	Transports: []transport.Transport{
		polling.Default,
		&websocket.Transport{
			// TODO: implement a better function to check origin.
			CheckOrigin: func(r *http.Request) bool {
				log.Println("Origin:", r.Header.Get("Origin"))
				return false
			},
		},
	},
}
sio := socketio.NewServer(opt)
// [...] Serve [...] 
```
2. Try to connect with a socketio client.

### Issue:
1. websocket/server.go fires u.ReturnError and sets http.Error(...)
2. go-engine.io/server.go ServeHTTP calls http.Error **again**

### Causes (warning on console):

_standard http:_
> http: superfluous response.WriteHeader call from github.com/googollee/go-engine%2eio.(*Server).ServeHTTP (server.go:146)

_gin:_
> [GIN-debug] [WARNING] Headers were already written. Wanted to override status code 403 with 502


