### PR TITLE
Fix runtime error on ARM architecture.

### DIFF
--- a/payload/payload.go
+++ b/payload/payload.go
@@ -18,20 +18,22 @@ type readArg struct {
 
 // Payload does encode or decode to payload protocol.
 type Payload struct {
+	feeding, flushing int64
+
 	close     chan struct{}
 	closeOnce sync.Once
 	err       atomic.Value
 
 	pauser *pauser
 
-	readerChan   chan readArg
-	feeding      int64
+	readerChan chan readArg
+	//feeding moved to the top to ensure correct 64bit-alignment on ARM/32bit arch.
 	readError    chan error
 	readDeadline atomic.Value
 	decoder      decoder
 
-	writerChan    chan io.Writer
-	flushing      int64
+	writerChan chan io.Writer
+	//flushing moved to the top to ensure correct 64bit-alignment on ARM/32bit arch.
 	writeError    chan error
 	writeDeadline atomic.Value
 	encoder       encoder


### PR DESCRIPTION
This should fix https://github.com/googollee/go-socket.io/issues/236

> [Bugs](https://golang.org/pkg/sync/atomic/#pkg-note-BUG) ¶
> ☞
> On x86-32, the 64-bit functions use instructions unavailable before the Pentium MMX.
> 
> On non-Linux ARM, the 64-bit functions use instructions unavailable before the ARMv6k core.
> 
> On ARM, x86-32, and 32-bit MIPS, it is the caller's responsibility to arrange for 64-bit alignment of 64-bit words accessed atomically. The first word in a variable or in an allocated struct, array, or slice can be relied upon to be 64-bit aligned.